### PR TITLE
Update GPIO Naming for Joule

### DIFF
--- a/grovebutton/README.md
+++ b/grovebutton/README.md
@@ -41,8 +41,7 @@ The GPIO line to be used is specified in the strings.xml file (src/res/values di
     <string name="Button_Edison_Arduino">IO0</string>
     <string name="Button_Edison_Sparkfun">GP20</string>
 
-    // TODO: Will need to change this string to reflect the updated pio_hal
-    <string name="Button_Joule_Tuchuck">DISPLAY_0_RST_N</string>
+    <string name="Button_Joule_Tuchuck">J6_1</string>
 </resources>
 ````
 

--- a/grovebutton/src/main/res/values/strings.xml
+++ b/grovebutton/src/main/res/values/strings.xml
@@ -4,6 +4,5 @@
     <string name="Button_Edison_Arduino">IO0</string>
     <string name="Button_Edison_Sparkfun">GP20</string>
 
-    // TODO: Will need to change this string to reflect the updated pio_hal
-    <string name="Button_Joule_Tuchuck">DISPLAY_0_RST_N</string>
+    <string name="Button_Joule_Tuchuck">J6_1</string>
 </resources>

--- a/grovebuzzer/src/main/res/values/strings.xml
+++ b/grovebuzzer/src/main/res/values/strings.xml
@@ -4,6 +4,5 @@
     <string name="Buzzer_Edison_Arduino">PWM0</string>
     <string name="Buzzer_Edison_Sparkfun">PWM0</string>
 
-    // TODO: Will need to change this string to reflect the updated pio_hal
-    <string name="Buzzer_Joule_Tuchuck">DISPLAY_0_RST_N</string>
+    <string name="Buzzer_Joule_Tuchuck">PWM_0</string>
 </resources>

--- a/groverelay/README.md
+++ b/groverelay/README.md
@@ -40,7 +40,7 @@ The GPIO line to be used is specified in the strings.xml file (src/res/values di
 
     <string name="Relay_Edison_Arduino">IO0</string>
     <string name="Relay_Edison_Sparkfun">GP20</string>
-    <string name="Relay_Joule_Tuchuck">DISPLAY_0_RST_N</string>
+    <string name="Relay_Joule_Tuchuck">J6_1</string>
 </resources>
 ````
 

--- a/groverelay/src/main/res/values/strings.xml
+++ b/groverelay/src/main/res/values/strings.xml
@@ -3,5 +3,5 @@
 
     <string name="Relay_Edison_Arduino">IO0</string>
     <string name="Relay_Edison_Sparkfun">GP20</string>
-    <string name="Relay_Joule_Tuchuck">DISPLAY_0_RST_N</string>
+    <string name="Relay_Joule_Tuchuck">J6_1</string>
 </resources>

--- a/grovetouch/README.md
+++ b/grovetouch/README.md
@@ -40,13 +40,13 @@ The GPIO line to be used is specified in the strings.xml file (src/res/values di
 
     <string name="Touch_Edison_Arduino">IO0</string>
     <string name="Touch_Edison_Sparkfun">GP20</string>
-    <string name="Touch_Joule_Tuchuck">DISPLAY_0_RST_N</string>
+    <string name="Touch_Joule_Tuchuck">J6_1</string>
 </resources>
 ````
 
 The code will automatically determine the board type being run on (modify BoardDefaults.java
 in the driver library to add another board) and select a string from this file for the GPIO line.
-The above example uses IO0 on the Edison Arduino shield and DISPLAY_0_RST_N on the Joule Tuchuck
+The above example uses IO0 on the Edison Arduino shield and J6_1 on the Joule Tuchuck
 development board. These strings are programmed into the Peripheral Manager and read from their
 into the UPM library to determine the GPIO pin to be used.
 

--- a/grovetouch/src/main/res/values/strings.xml
+++ b/grovetouch/src/main/res/values/strings.xml
@@ -3,5 +3,5 @@
 
     <string name="Touch_Edison_Arduino">IO0</string>
     <string name="Touch_Edison_Sparkfun">GP20</string>
-    <string name="Touch_Joule_Tuchuck">DISPLAY_0_RST_N</string>
+    <string name="Touch_Joule_Tuchuck">J6_1</string>
 </resources>


### PR DESCRIPTION
DP4 Joule changes the GPIO names in the peripheral manager
to correspond to the TuChuck connector-pin.

Signed-off-by: Bruce Beare <bruce.j.beare@intel.com>