### PR TITLE
Use the latest versions of UPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ Importing UPM Android studio projects
 
    ````
    dependencies {
-       compile 'io.mraa.at.upm:upm_jhd1313m1:1.1.0'
+       compile 'io.mraa.at.upm:upm_jhd1313m1:1.3.0'
        compile project(':driversupport')
        provided 'com.google.android.things:androidthings:0.3-devpreview'
    }
     ````
 
-   This build script pulls in io.mraa.at.upm:upm_jhd1313m1:1.1.0 from jcenter and includes the
+   This build script pulls in io.mraa.at.upm:upm_jhd1313m1:1.3.0 from jcenter and includes the
    driverlibrary from this project as well. Driverlibrary includes some common functions as well as
    an example sensor manager plug-in for the MMA 7660 Accelerometer.
 

--- a/accel_on_lcd/build.gradle
+++ b/accel_on_lcd/build.gradle
@@ -43,7 +43,7 @@ android {
 }
 
 dependencies {
-    compile 'io.mraa.at.upm:upm_jhd1313m1:1.1.0'
+    compile 'io.mraa.at.upm:upm_jhd1313m1:1.+'
     compile project(':driversupport')
     compile project(':driverlibrary')
     provided 'com.google.android.things:androidthings:0.3-devpreview'

--- a/bme280/build.gradle
+++ b/bme280/build.gradle
@@ -30,5 +30,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':driversupport')
-    compile 'io.mraa.at.upm:upm_bmp280:1.2.0'
+    compile 'io.mraa.at.upm:upm_bmp280:1.+'
 }

--- a/driverlibrary/build.gradle
+++ b/driverlibrary/build.gradle
@@ -43,6 +43,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'io.mraa.at.upm:upm_mma7660:1.1.0'
+    compile 'io.mraa.at.upm:upm_mma7660:1.+'
     provided 'com.google.android.things:androidthings:0.3-devpreview'
 }

--- a/driversupport/build.gradle
+++ b/driversupport/build.gradle
@@ -43,6 +43,6 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'io.mraa.at:mraa:1.6.1'
+    compile 'io.mraa.at:mraa:1.+'
     provided 'com.google.android.things:androidthings:0.3-devpreview'
 }

--- a/grovebutton/build.gradle
+++ b/grovebutton/build.gradle
@@ -32,5 +32,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':driversupport')
-    compile 'io.mraa.at.upm:upm_grove:1.1.0'
+    compile 'io.mraa.at.upm:upm_grove:1.+'
 }

--- a/grovebuzzer/build.gradle
+++ b/grovebuzzer/build.gradle
@@ -32,5 +32,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':driversupport')
-    compile 'io.mraa.at.upm:upm_buzzer:1.2.0'
+    compile 'io.mraa.at.upm:upm_buzzer:1.+'
 }

--- a/groveled/build.gradle
+++ b/groveled/build.gradle
@@ -32,5 +32,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':driversupport')
-    compile 'io.mraa.at.upm:upm_grove:1.1.0'
+    compile 'io.mraa.at.upm:upm_grove:1.+'
 }

--- a/groverelay/build.gradle
+++ b/groverelay/build.gradle
@@ -31,5 +31,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':driversupport')
-    compile 'io.mraa.at.upm:upm_grove:1.1.0'
+    compile 'io.mraa.at.upm:upm_grove:1.+'
 }

--- a/grovetouch/build.gradle
+++ b/grovetouch/build.gradle
@@ -32,5 +32,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':driversupport')
-    compile 'io.mraa.at.upm:upm_ttp223:1.1.0'
+    compile 'io.mraa.at.upm:upm_ttp223:1.+'
 }

--- a/jhd1313m1/build.gradle
+++ b/jhd1313m1/build.gradle
@@ -43,20 +43,7 @@ android {
 }
 
 dependencies {
-    compile 'io.mraa.at.upm:upm_jhd1313m1:1.1.0'
+    compile 'io.mraa.at.upm:upm_jhd1313m1:1.+'
     compile project(':driversupport')
     provided 'com.google.android.things:androidthings:0.3-devpreview'
-}
-
-repositories {
-    jcenter()
-}
-
-buildscript {
-    repositories {
-        jcenter()
-    }
-    dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.1'
-    }
 }

--- a/tmp006/build.gradle
+++ b/tmp006/build.gradle
@@ -31,5 +31,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile project(':driversupport')
-    compile 'io.mraa.at.upm:upm_tmp006:1.2.0'
+    compile 'io.mraa.at.upm:upm_tmp006:1.+'
 }


### PR DESCRIPTION
Switch all examples to use the "+" versioning syntax so that they will
take the latest version of UPM and MRAA libraries. This isn't recommended
for production code but for examples is reasonable.

Signed-off-by: Bruce Beare <bruce.j.beare@intel.com>